### PR TITLE
Add extra data to Pong-Atari2600

### DIFF
--- a/retro/data/stable/Pong-Atari2600/data.json
+++ b/retro/data/stable/Pong-Atari2600/data.json
@@ -1,5 +1,21 @@
 {
   "info": {
+    "ball_x": {
+      "address": 177,
+      "type": "|u1"
+    },
+    "ball_y": {
+      "address": 182,
+      "type": "|u1"
+    },
+    "p1_pos": {
+      "address": 188,
+      "type": "|u1"
+    },
+    "p2_pos": {
+      "address": 178,
+      "type": "|u1"
+    },
     "score1": {
       "address": 141,
       "type": "|u1"


### PR DESCRIPTION
Added positions for p1, p2 and the ball. Useful for debugging and be able to train directly with game information