### PR TITLE
Temp fix segmentation fault when compiling integration tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,8 +259,6 @@ if(NOT CAPN_PROTO_FOUND AND NOT BUILD_MANYLINUX)
   endif()
 endif()
 
-# Temporarily force disable CAPNPROTO since it currently causes random seg faults when building the project
-# https://github.com/Farama-Foundation/stable-retro/issues/65
 set(CAPN_PROTO_FOUND OFF)
 
 if(CAPN_PROTO_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,6 +259,10 @@ if(NOT CAPN_PROTO_FOUND AND NOT BUILD_MANYLINUX)
   endif()
 endif()
 
+# Temporarily force disable CAPNPROTO since it currently causes random seg faults when building the project
+# https://github.com/Farama-Foundation/stable-retro/issues/65
+set(CAPN_PROTO_FOUND OFF)
+
 if(CAPN_PROTO_FOUND)
   add_definitions(-DUSE_CAPNP)
 


### PR DESCRIPTION
Temp fix segmentation fault when compiling integration tool by disabling capnproto in CMakeLists.txt