### PR TITLE
Disable capnproto in UI CMakeLists.txt to fix link error when building integration tool

### DIFF
--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -9,10 +9,11 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 file(GLOB SRC *.cpp)
 
 set(RETRO_EXTRA)
-
-# if(CapnProto_FOUND)
-#   list(APPEND RETRO_EXTRA retro-capnp)
-# endif()
+# Temporarily disable CapnProto until we upgrade it to a newer version
+set(CapnProto_FOUND OFF)
+if(CapnProto_FOUND)
+  list(APPEND RETRO_EXTRA retro-capnp)
+endif()
 
 get_target_property(QT_TYPE Qt5::Core TYPE)
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -10,9 +10,9 @@ file(GLOB SRC *.cpp)
 
 set(RETRO_EXTRA)
 
-#if(CapnProto_FOUND)
-#  list(APPEND RETRO_EXTRA retro-capnp)
-#endif()
+# if(CapnProto_FOUND)
+#   list(APPEND RETRO_EXTRA retro-capnp)
+# endif()
 
 get_target_property(QT_TYPE Qt5::Core TYPE)
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -10,9 +10,9 @@ file(GLOB SRC *.cpp)
 
 set(RETRO_EXTRA)
 
-if(CapnProto_FOUND)
-  list(APPEND RETRO_EXTRA retro-capnp)
-endif()
+#if(CapnProto_FOUND)
+#  list(APPEND RETRO_EXTRA retro-capnp)
+#endif()
 
 get_target_property(QT_TYPE Qt5::Core TYPE)
 

--- a/src/ui/CMakeLists.txt
+++ b/src/ui/CMakeLists.txt
@@ -10,10 +10,9 @@ file(GLOB SRC *.cpp)
 
 set(RETRO_EXTRA)
 # Temporarily disable CapnProto until we upgrade it to a newer version
-set(CapnProto_FOUND OFF)
-if(CapnProto_FOUND)
-  list(APPEND RETRO_EXTRA retro-capnp)
-endif()
+#if(CapnProto_FOUND)
+#  list(APPEND RETRO_EXTRA retro-capnp)
+#endif()
 
 get_target_property(QT_TYPE Qt5::Core TYPE)
 


### PR DESCRIPTION
I temporarily disabled  capnproto meanwhile we update it to the new version but I forgot to disable it in the UI cmakelists.txt as well which obviously causes build errors