### PR TITLE
Enable building Python 3.12 manylinux wheels 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,11 @@ requires = ["cmake>=3.2.0", "setuptools", "wheel", "build"]
 
 [tool.cibuildwheel]
 # We need to build for the following Python versions:
-build = "cp{38,39,310,311}-*"
+build = "cp{38,39,310,311,312}-*"
 
 [tool.cibuildwheel.linux]
 # Only manylinux is supported (no musl)
-build = "cp{38,39,310,311}-manylinux*"
+build = "cp{38,39,310,311,312}-manylinux*"
 
 # For manylinux_2_28 we need to install the following dependencies using yum:
 before-all = "yum install -y cmake git pkgconf-pkg-config zlib-devel libzip-devel bzip2-devel"

--- a/tests/test_cibuildwheel/install_and_test_wheel.sh
+++ b/tests/test_cibuildwheel/install_and_test_wheel.sh
@@ -8,19 +8,32 @@ cd $( dirname "${BASH_SOURCE[0]}" )/../..
 ls -lha .
 
 # Report python version
-python3 --version
 python3 -c "import sys; print('Python', sys.version)"
 
 # Find matching wheel file in wheelhouse
-PYTHON_VERSION=$(python3 -c "import sys; print('{}{}'.format(sys.version_info.major, sys.version_info.minor))")
+PYTHON_VERSION_MAJOR=$(python3 -c "import sys; print(sys.version_info.major)")
+PYTHON_VERSION_MINOR=$(python3 -c "import sys; print(sys.version_info.minor)")
+PYTHON_VERSION="${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}"
 PYTHON_WHEEL=$(ls wheelhouse/stable_retro-*-cp${PYTHON_VERSION}-cp${PYTHON_VERSION}*.whl)
 
+if [ -z "${PYTHON_WHEEL}" ]; then
+    echo "No matching wheel file was found"
+    exit 1
+fi
+
+# Workaround for environment being externally managed in system installed Python 3.11+
+PIP_FLAGS=""
+if (( ${PYTHON_VERSION_MINOR} >= 11 )); then
+    echo "Adding --break-system-packages flag to pip install"
+    PIP_FLAGS="--break-system-packages"
+fi
+
 # Updgrad pip and install test deps
-python3 -m pip install --upgrade pip
-python3 -m pip install pytest psutil
+python3 -m pip install --upgrade pip ${PIP_FLAGS}
+python3 -m pip install pytest psutil ${PIP_FLAGS}
 
 # Install wheel
-python3 -m pip install ${PYTHON_WHEEL}
+python3 -m pip install ${PYTHON_WHEEL} ${PIP_FLAGS}
 
 # Test import
 python3 -c "import retro"

--- a/tests/test_cibuildwheel/test_cibuildwheel_linux.sh
+++ b/tests/test_cibuildwheel/test_cibuildwheel_linux.sh
@@ -13,14 +13,17 @@ IMAGE_PREFIX="stable-retro_wheels"
 
 # Array in format "<base docker image> <base dockerfile to use> <additional commands to add to the dockerfile after FROM statement>"
 DOCKERFILES_TO_BUILD_AND_RUN=(
-    "debian:11.6 apt-based.Dockerfile ENV LANG C.UTF-8"  # Python 3.9
+    "debian:11 apt-based.Dockerfile ENV LANG C.UTF-8"  # Python 3.9
+    "debian:latest apt-based.Dockerfile ENV LANG C.UTF-8"  # Python 3.11
     "ubuntu:20.04 apt-based.Dockerfile"  # Python 3.8
     "ubuntu:22.04 apt-based.Dockerfile"  # Python 3.10
-    #"continuumio/miniconda3:latest conda-based.Dockerfile"  # Python 3.11 - not supported at the moment
+    "ubuntu:23.04 apt-based.Dockerfile"  # Python 3.11
+    "ubuntu:latest apt-based.Dockerfile"  # Python 3.11
+    "continuumio/miniconda3:latest conda-based.Dockerfile"  # Python 3.11
     #"almalinux:9 dnf-based.Dockerfile"  # Python 3.9  - test doesn't work becouse of pyglet requirement for X server
     #"rockylinux:9 dnf-based.Dockerfile"  # Python 3.9 - as above
     #"fedora:36 dnf-based.Dockerfile"  # Python 3.10 - as above
-    #"fedora:37 dnf-based.Dockerfile"  # Python 3.11 - not supported at the moment
+    #"fedora:37 dnf-based.Dockerfile"  # Python 3.11 - as above
 )
 
 # Clean local directory to avoid problems


### PR DESCRIPTION
This is a small PR that enables building manylinux wheels for Python 3.12 by cibuildwheels in https://github.com/Farama-Foundation/stable-retro/blob/master/.github/workflows/build-publish.yml workflow.

Additionally, it adds the latest Ubuntu/Debian and Minicoda images to the manual cibuildwheels test.