### PR TITLE
Added X and Y positions for player and enemy in Mortal Kombat 2

### DIFF
--- a/retro/data/stable/MortalKombatII-Genesis/data.json
+++ b/retro/data/stable/MortalKombatII-Genesis/data.json
@@ -19,6 +19,22 @@
     "wins": {
       "address": 16772772,
       "type": "|d1"
+    },
+    "x_position": {
+      "address": 16758472,
+      "type": ">u2"
+    },
+    "enemy_x_position": {
+      "address": 16758712,
+      "type": ">u2"
+    },
+    "y_position": {
+    "address": 16758500,  
+    "type": ">i2"
+    },
+    "enemy_y_position": {
+      "address": 16758740, 
+      "type": ">i2"
     }
   }
 }


### PR DESCRIPTION
This pull request adds memory addresses for both player and enemy **X** and **Y** positions for _Mortal Kombat 2: Genesis_ . The changes made: 

- **Player X Position**: Added `x_position` at address `16758472` (`0xFFB6C8`), using the type `>u2`.
- **Enemy X Position**: Added `enemy_x_position` at address `16758712` (`0xFFB7B8`), using the type `>u2`.
- **Player Y Position**: Added `y_position` at address `16758500` (`0xFFB6E4`), using the type `>i2`.
- **Enemy Y Position**: Added `enemy_y_position` at address `16758740` (`0xFFB7D4`), using the type `>i2`.

The memory addresses were identified using BizHawk’s RAM search tool and tested locally. 
