### PR TITLE
Debugging why the latest version on pypi only contains macos wheels

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-14]
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Debugging why the latest version on pypi only contains macos wheels