### PR TITLE
Bug fixes for scripts in ./retro/examples for modern Gymnasium

### DIFF
--- a/retro/examples/brute.py
+++ b/retro/examples/brute.py
@@ -14,7 +14,7 @@ import random
 
 import gymnasium as gym
 import numpy as np
-from gymnasium.wrappers.time_limit import TimeLimit
+from gymnasium.wrappers import TimeLimit
 
 import retro
 
@@ -26,8 +26,8 @@ class Frameskip(gym.Wrapper):
         super().__init__(env)
         self._skip = skip
 
-    def reset(self):
-        return self.env.reset()
+    def reset(self, *, seed=None, options=None):
+        return self.env.reset(seed=seed, options=options)
 
     def step(self, act):
         total_rew = 0.0

--- a/retro/examples/determinism.py
+++ b/retro/examples/determinism.py
@@ -31,12 +31,14 @@ class MoreDeterministicRetroState(gym.Wrapper):
     def __init__(self, *args, reset_on_step=True, **kwargs):
         super().__init__(*args, **kwargs)
         self._last_obs = None
-        self._done = False
+        self._terminated = False
+        self._truncated = False
         # if retro were more deterministic, this would not be necessary
         self._reset_on_step = reset_on_step
 
     def reset(self, state=None):
-        self._done = False
+        self._terminated = False
+        self._truncated = False
         if state is not None:
             em_state, self._last_obs = state
             self.unwrapped.em.set_state(em_state)
@@ -46,23 +48,28 @@ class MoreDeterministicRetroState(gym.Wrapper):
             self._last_obs = self.env.reset()
         return self._last_obs
 
+    def get_ram(self):
+        # expose get_ram
+        return self.unwrapped.get_ram()
+
     def step(self, act):
         if self._reset_on_step:
             self.reset(state=self.get_state())
-        self._last_obs, rew, self._done, info = self.env.step(act)
-        return self._last_obs, rew, self._done, info
+        #self._last_obs, rew, self._done, info = self.env.step(act)
+        self._last_obs, rew, self._terminated, self._truncated, info = self.env.step(act)
+        return self._last_obs, rew, self._terminated, self._truncated, info
 
     def get_state(self):
-        assert not self._done, "cannot store a terminal state"
+        assert not (self._terminated or self._truncated), "cannot store a terminal state"
         return (self.unwrapped.em.get_state(), self._last_obs)
 
 
 def rollout(env, acts):
     total_rew = 0.0
     for act in acts:
-        _obs, rew, done, _info = env.step(act)
+        _obs, rew, terminated, truncated, _info = env.step(act)
         total_rew += rew
-        if done:
+        if terminated or truncated:
             break
     return total_rew
 
@@ -90,8 +97,8 @@ def check_env_helper(make_env, all_acts, verbose, out_success):
     # truncate actions to end before done
     valid_acts = []
     for act in all_acts:
-        _obs, _rew, done, _info = env.step(act)
-        if done:
+        _obs, _rew, terminated, truncated, _info = env.step(act)
+        if terminated or truncated:
             break
         valid_acts.append(act)
 

--- a/retro/examples/determinism.py
+++ b/retro/examples/determinism.py
@@ -55,7 +55,6 @@ class MoreDeterministicRetroState(gym.Wrapper):
     def step(self, act):
         if self._reset_on_step:
             self.reset(state=self.get_state())
-        #self._last_obs, rew, self._done, info = self.env.step(act)
         self._last_obs, rew, self._terminated, self._truncated, info = self.env.step(act)
         return self._last_obs, rew, self._terminated, self._truncated, info
 

--- a/retro/examples/ppo.py
+++ b/retro/examples/ppo.py
@@ -6,7 +6,7 @@ import argparse
 
 import gymnasium as gym
 import numpy as np
-from gymnasium.wrappers.time_limit import TimeLimit
+from gymnasium.wrappers import TimeLimit
 from stable_baselines3 import PPO
 from stable_baselines3.common.atari_wrappers import ClipRewardEnv, WarpFrame
 from stable_baselines3.common.vec_env import (

--- a/retro/examples/retro_interactive.py
+++ b/retro/examples/retro_interactive.py
@@ -1,6 +1,5 @@
 import argparse
 
-from baselines.common.vec_env.subproc_vec_env import SubprocVecEnv
 
 import retro
 from retro.examples.interactive import Interactive
@@ -12,17 +11,17 @@ class RetroInteractive(Interactive):
     """
 
     def __init__(self, game, state, scenario):
-        def make_env():
-            return retro.make(game=game, state=state, scenario=scenario)
-
-        env = make_env()
+        env = retro.make(
+            game=game,
+            state=state,
+            scenario=scenario,
+            render_mode="rgb_array",
+        )
         self._buttons = env.buttons
-        env.close()
-        venv = SubprocVecEnv([make_env])
-        super().__init__(venv=venv, sync=False, tps=60, aspect_ratio=4 / 3)
+        super().__init__(env=env, sync=False, tps=60, aspect_ratio=4 / 3)
 
-    def get_screen(self, _obs, venv):
-        return venv.render(mode="rgb_array")
+    def get_image(self, _obs, env):
+        return env.render()
 
     def keys_to_act(self, keys):
         inputs = {

--- a/retro/examples/trivial_random_agent_multiplayer.py
+++ b/retro/examples/trivial_random_agent_multiplayer.py
@@ -7,11 +7,11 @@ def main():
     while True:
         # action_space will by MultiBinary(16) now instead of MultiBinary(8)
         # the bottom half of the actions will be for player 1 and the top half for player 2
-        obs, rew, done, info = env.step(env.action_space.sample())
+        obs, rew, terminated, truncated, info = env.step(env.action_space.sample())
         # rew will be a list of [player_1_rew, player_2_rew]
         # done and info will remain the same
         env.render()
-        if done:
+        if terminated or truncated:
             env.reset()
     env.close()
 


### PR DESCRIPTION
These commits fix issues with a number of the example scripts in ./retro/examples. Most of these changes revolve around changes to the Gymnasium API. 

in stable-retro setup.py, it requests "gymnasium>=0.27.1"

- Gymnasium v26+ has removed `done` in gymnasium.Wrapper in favor of `truncated` and `terminated`: https://gymnasium.farama.org/main/introduction/migration-guide/

- I cannot find explicitly which version of Gymnasium flattened the wrapper names but I had to change a few instances of 
`from gymnasium.wrappers.time_limit import TimeLimit`
to
`from gymnasium.wrappers import TimeLimit`

- For retro_interactive I changed to plain env and tweaked the methods to match what is in interactive.py

When testing in my environment I can now reliably run all the example scripts.