### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/third-party/luajit/src/lj_err.c
+++ b/third-party/luajit/src/lj_err.c
@@ -585,6 +585,7 @@ static ptrdiff_t finderrfunc(lua_State *L)
       if (cframe_canyield(cf)) return 0;
       if (cframe_errfunc(cf) >= 0)
 	return cframe_errfunc(cf);
+      cf = cframe_prev(cf);
       frame = frame_prevd(frame);
       break;
     case FRAME_PCALL:


### PR DESCRIPTION
### Summary

Our tool detected a potential vulnerability in `finderrfunc()` in `third-party/luajit/src/lj_err.c` which was cloned from https://github.com/LuaJIT/LuaJIT/commit/53f82e6e2e858a0a62fd1a2ff47e9866693382e6 but did not receive the security patch. The original issue was reported and fixed under [CVE-2020-15890](https://nvd.nist.gov/vuln/detail/CVE-2020-15890).

### Proposed Fix

Apply the same patch as the one in LuaJIT/LuaJIT to eliminate the vulnerability.

### Reference

https://nvd.nist.gov/vuln/detail/CVE-2020-15890
https://github.com/LuaJIT/LuaJIT/commit/53f82e6e2e858a0a62fd1a2ff47e9866693382e6