### PR TITLE
docs: replace stale Python-versions line with a pyversions badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Python](https://img.shields.io/pypi/pyversions/stable-retro.svg)](https://pypi.org/project/stable-retro/) [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 <p align="center">
     <a href="https://gymnasium.farama.org/" target = "_blank">
@@ -140,8 +140,6 @@ Platforms:
 - Linux (manylinux1). Ubuntu 22.04 is recommended
 
 CPU with `SSE3` or better
-
-Supported Pythons: 3.7 to 3.12
 
 ## Citation
 

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,14 @@ setup(
         "farama-notifications>=0.0.1",
     ],
     python_requires=">=3.8.0,<3.13",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+    ],
     ext_modules=[Extension("stable_retro._retro", ["CMakeLists.txt", "src/*.cpp"])],
     cmdclass={"build_ext": CMakeBuild},
     packages=[


### PR DESCRIPTION
## Description

The README hardcoded `Supported Pythons: 3.7 to 3.12`, but the package requires `>=3.8.0,<3.13` (`setup.py`) and CI only tests `3.8`–`3.12` — so `3.7` was incorrect.

This replaces the manually-maintained line with the dynamic shields.io `pyversions` badge in the README's top badge row (matching other Farama projects), so the supported-versions info stays correct across future releases without manual edits. This follows the approach suggested by the issue reporter.

## Changes

- **README.md** — add `[![Python](https://img.shields.io/pypi/pyversions/stable-retro.svg)](https://pypi.org/project/stable-retro/)` to the top badge row, and remove the stale `Supported Pythons: 3.7 to 3.12` line.
- **setup.py** — add `Programming Language :: Python :: 3.8`…`3.12` trove classifiers. The `pyversions` badge reads these from PyPI, and `stable-retro` currently ships none.

## Note on the badge

The `pyversions` badge resolves from PyPI **trove classifiers**, not from `requires-python`. The latest published `stable-retro` release has no Python classifiers, so the badge will render `python | missing` until a release **including these classifiers** is published. After the next release it will show `3.8 | 3.9 | 3.10 | 3.11 | 3.12`.

## Verification

- `pre-commit run --files README.md setup.py` — all hooks pass (black, isort, flake8, pyupgrade, add-trailing-comma).
- `autopep8 --diff setup.py` — no changes (PEP8-clean, per `scripts/lint.sh`).
- `setup.py` parses; the classifiers match `python_requires` and the CI test matrix.
- No runtime code is changed, so the test suite is unaffected.

Fixes #227
