### PR TITLE
Fix workflow branch filters for main

### DIFF
--- a/.github/workflows/build-docs-dev.yml
+++ b/.github/workflows/build-docs-dev.yml
@@ -1,9 +1,9 @@
 name: Build main branch documentation website
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 permissions:
   contents: write
 jobs:

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -9,9 +9,9 @@ name: build-publish
 on:
   workflow_dispatch:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
   release:
     types: [published]
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,7 +4,7 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read # to fetch code (actions/checkout)


### PR DESCRIPTION
Update the remaining GitHub Actions workflows that still target the old master branch to use main instead.

This restores build-publish on the current default branch and keeps the docs and pre-commit workflows aligned with the same trigger.