### PR TITLE
Potential fix for code scanning alert no. 6: Clear-text storage of sensitive information

### DIFF
--- a/cores/flycast/intl/crowdin_translation_download.py
+++ b/cores/flycast/intl/crowdin_translation_download.py
@@ -23,12 +23,9 @@ if __name__ == '__main__':
    DIR_PATH = t.os.path.dirname(t.os.path.realpath(__file__))
    YAML_PATH = t.os.path.join(DIR_PATH, 'crowdin.yaml')
 
-   # Apply Crowdin API Key
+   # Apply core name placeholder (do not persist API token to disk)
    with open(YAML_PATH, 'r') as crowdin_config_file:
       crowdin_config = crowdin_config_file.read()
-   crowdin_config = re.sub(r'"api_token": "_secret_"',
-                           f'"api_token": "{API_KEY}"',
-                           crowdin_config, 1)
    crowdin_config = re.sub(r'/_core_name_',
                            f'/{CORE_NAME}'
                            , crowdin_config)
@@ -58,16 +55,11 @@ if __name__ == '__main__':
             shutil.rmtree(jar_dir)
 
       print('download translation *.json')
-      subprocess.run(['java', '-jar', jar_path, 'download', '--config', YAML_PATH])
+      crowdin_env = os.environ.copy()
+      crowdin_env['CROWDIN_PERSONAL_TOKEN'] = API_KEY
+      subprocess.run(['java', '-jar', jar_path, 'download', '--config', YAML_PATH], env=crowdin_env)
 
-      # Reset Crowdin API Key
-      with open(YAML_PATH, 'r') as crowdin_config_file:
-         crowdin_config = crowdin_config_file.read()
-      crowdin_config = re.sub(r'"api_token": ".*?"',
-                              '"api_token": "_secret_"',
-                              crowdin_config, 1)
-
-      # TODO this is NOT safe!
+      # Restore core name placeholder
       crowdin_config = re.sub(re.escape(f'/{CORE_NAME}'),
                               '/_core_name_',
                               crowdin_config)
@@ -76,14 +68,10 @@ if __name__ == '__main__':
          crowdin_config_file.write(crowdin_config)
 
    except Exception as e:
-      # Try really hard to reset Crowdin API Key
+      # Try really hard to restore core name placeholder
       with open(YAML_PATH, 'r') as crowdin_config_file:
          crowdin_config = crowdin_config_file.read()
-      crowdin_config = re.sub(r'"api_token": ".*?"',
-                              '"api_token": "_secret_"',
-                              crowdin_config, 1)
 
-      # TODO this is NOT safe!
       crowdin_config = re.sub(re.escape(f'/{CORE_NAME}'),
                               '/_core_name_',
                               crowdin_config)


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Stable-Retro/security/code-scanning/6](https://github.com/Farama-Foundation/Stable-Retro/security/code-scanning/6)

General fix: do not persist secrets to files. Keep the token in memory and provide it only at execution time through a less persistent channel (process environment). Also avoid mutating `crowdin.yaml` with the token.

Best fix here (without changing functionality): keep replacing only `/_core_name_` in `crowdin.yaml`, but remove all code that writes `api_token` into the YAML. Then call Crowdin CLI with an environment variable containing the token (Crowdin CLI supports token via env var), using `subprocess.run(..., env=...)`. This preserves behavior (CLI still authenticates) while eliminating clear-text token-at-rest in project files.

Edits needed in `cores/flycast/intl/crowdin_translation_download.py`:
- Remove the “Apply Crowdin API Key” substitution block for `"api_token": "_secret_"` and the corresponding reset logic for api token in both `try` and `except`.
- Keep/update only core-name placeholder substitution and restoration.
- Add environment construction before `subprocess.run` and pass `CROWDIN_PERSONAL_TOKEN` via `env`.
- Keep cleanup for `/_core_name_` in both success and exception paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
