### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete URL substring sanitization

### DIFF
--- a/third-party/gtest/googlemock/scripts/upload.py
+++ b/third-party/gtest/googlemock/scripts/upload.py
@@ -759,20 +759,21 @@ class SubversionVCS(VersionControlSystem):
         username, netloc = urllib.splituser(netloc)
         if username:
           logging.info("Removed username from base URL")
-        if netloc.endswith("svn.python.org"):
-          if netloc == "svn.python.org":
+        host = netloc.split(":", 1)[0].lower()
+        if host == "svn.python.org" or host.endswith(".svn.python.org"):
+          if host == "svn.python.org":
             if path.startswith("/projects/"):
               path = path[9:]
           elif netloc != "pythondev@svn.python.org":
             ErrorExit("Unrecognized Python URL: %s" % url)
           base = "http://svn.python.org/view/*checkout*%s/" % path
           logging.info("Guessed Python base = %s", base)
-        elif netloc.endswith("svn.collab.net"):
+        elif host == "svn.collab.net" or host.endswith(".svn.collab.net"):
           if path.startswith("/repos/"):
             path = path[6:]
           base = "http://svn.collab.net/viewvc/*checkout*%s/" % path
           logging.info("Guessed CollabNet base = %s", base)
-        elif netloc.endswith(".googlecode.com"):
+        elif host.endswith(".googlecode.com"):
           path = path + "/"
           base = urlparse.urlunparse(("http", netloc, path, params,
                                       query, fragment))


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/Stable-Retro/security/code-scanning/4](https://github.com/Farama-Foundation/Stable-Retro/security/code-scanning/4)

Use exact hostname checks (or boundary-safe subdomain checks) on the parsed host, instead of raw suffix matching on `netloc`.

Best fix here without changing intended behavior:
- In `third-party/gtest/googlemock/scripts/upload.py`, inside `_GuessBase`, after `urllib.splituser(netloc)`, normalize host by removing any port and lowercasing it.
- Replace `netloc.endswith("svn.collab.net")` with a boundary-safe check:
  - `host == "svn.collab.net"` or `host.endswith(".svn.collab.net")`
- Keep existing behavior for URL construction unchanged (continue using `netloc` when building URLs), so functionality remains the same except the host classification is now correct and robust.

No new dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
