### PR TITLE
fix: prevent legacy zlib headers breaking macOS builds

### DIFF
--- a/cores/flycast/core/deps/zlib/zutil.h
+++ b/cores/flycast/core/deps/zlib/zutil.h
@@ -118,7 +118,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if !defined(__APPLE__) && (defined(MACOS) || defined(TARGET_OS_MAC))
 #  define OS_CODE  0x07
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os

--- a/cores/genesis/core/cd_hw/libchdr/deps/zlib/zutil.h
+++ b/cores/genesis/core/cd_hw/libchdr/deps/zlib/zutil.h
@@ -130,7 +130,7 @@ extern z_const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if !defined(__APPLE__) && (defined(MACOS) || defined(TARGET_OS_MAC))
 #  define OS_CODE  7
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os

--- a/cores/pce/deps/zlib/zutil.h
+++ b/cores/pce/deps/zlib/zutil.h
@@ -118,7 +118,7 @@ extern const char * const z_errmsg[10]; /* indexed by 2-zlib_error */
 #  endif
 #endif
 
-#if defined(MACOS) || defined(TARGET_OS_MAC)
+#if !defined(__APPLE__) && (defined(MACOS) || defined(TARGET_OS_MAC))
 #  define OS_CODE  0x07
 #  ifndef Z_SOLO
 #    if defined(__MWERKS__) && __dest_os != __be_os && __dest_os != __win32_os

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,7 @@ manylinux-x86_64-image = "manylinux_2_28"
 manylinux-aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.macos]
-before-all = "brew install pkg-config capnp lua@5.4 qt5"
+# Wheel builds use bundled LuaJIT, the vendored libzip fallback, and keep the
+# optional Qt integration UI disabled. Avoid Homebrew bootstrap here because
+# GitHub's macOS runners now enforce tap trust and `qt@5` is deprecated.
+before-all = "true"


### PR DESCRIPTION
Fixes macOS wheel builds on current `macos-latest` runners.

Several vendored zlib headers use a legacy fallback that defines `fdopen` for old Apple targets. Modern macOS SDKs already declare `fdopen`, so that macro expands inside the SDK’s `_stdio.h` and prevents the affected emulator cores from compiling.

This PR updates the affected zlib headers to skip that fallback when building on modern macOS.

It also removes the macOS wheel job’s unnecessary Homebrew bootstrap, which was failing on runner tap-trust checks before the native build started.
