### PR TITLE
Improve Copilot repository onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug report
+description: Report a reproducible Stable Retro problem.
+title: "[Bug]: "
+body:
+  - type: dropdown
+    id: area
+    attributes:
+      label: Affected area
+      options:
+        - Python API
+        - Native runtime
+        - Emulator core or platform
+        - Game integration
+        - Build or packaging
+        - Integration UI
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: summary
+    attributes:
+      label: Problem
+      description: Describe what went wrong and when it began.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Provide the smallest complete sequence that reproduces the problem without attaching copyrighted ROMs or BIOS files.
+      placeholder: |
+        1. Install ...
+        2. Run ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Stable Retro version or commit
+      placeholder: 0.9.5 or abc1234
+    validations:
+      required: true
+  - type: input
+    id: system
+    attributes:
+      label: Operating system and architecture
+      placeholder: Ubuntu 24.04 x86_64
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: 3.12.8
+    validations:
+      required: true
+  - type: input
+    id: emulator
+    attributes:
+      label: Emulator platform and core
+      description: Required for emulator or game-specific problems.
+      placeholder: NintendoDs / melonDS
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs and additional context
+      description: Paste complete text logs and remove secrets or copyrighted data.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues for this problem.
+          required: true
+        - label: I have not attached a commercial ROM, BIOS, key, or other copyrighted asset.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Stable Retro documentation
+    url: https://stable-retro.farama.org/
+    about: Read installation, API, integration, and emulator documentation.

--- a/.github/ISSUE_TEMPLATE/emulator_platform.yml
+++ b/.github/ISSUE_TEMPLATE/emulator_platform.yml
@@ -1,0 +1,59 @@
+name: Emulator platform or core
+description: Propose support for a new game system or libretro core.
+title: "[Platform]: "
+body:
+  - type: input
+    id: platform
+    attributes:
+      label: Platform or game system
+      placeholder: Nintendo Example System
+    validations:
+      required: true
+  - type: input
+    id: core
+    attributes:
+      label: Proposed libretro core and upstream URL
+    validations:
+      required: true
+  - type: input
+    id: revision
+    attributes:
+      label: Tested upstream revision
+      description: Provide a commit hash or release tag when available.
+  - type: textarea
+    id: license
+    attributes:
+      label: License and redistribution
+      description: Identify the core license and any BIOS, firmware, or key requirements.
+    validations:
+      required: true
+  - type: textarea
+    id: hosts
+    attributes:
+      label: Host platform support
+      description: State what is known for Linux, Windows, macOS x86_64, and macOS arm64.
+    validations:
+      required: true
+  - type: textarea
+    id: behavior
+    attributes:
+      label: Runtime behavior
+      description: Cover rendering, audio, input, RAM access, reset, and serialization support.
+    validations:
+      required: true
+  - type: textarea
+    id: testing
+    attributes:
+      label: Test strategy
+      description: Identify a redistributable fixture or explain how automated and manual testing can be performed without commercial assets.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing platform and core requests.
+          required: true
+        - label: I will not submit commercial ROMs, BIOS files, or keys without redistribution permission.
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: Feature request
+description: Propose a Stable Retro feature or API improvement.
+title: "[Feature]: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: Describe the user need rather than only the proposed implementation.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Explain the API or behavior and include a brief usage example when useful.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+  - type: textarea
+    id: compatibility
+    attributes:
+      label: Compatibility and testing
+      description: Note public API, Python version, operating system, core, performance, or serialization implications.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I searched existing issues and pull requests for this request.
+          required: true

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# Stable Retro Repository Instructions
+
+Stable Retro is an actively developed Gymnasium-compatible fork of OpenAI Gym Retro. It combines a Python API, a C++14 extension, and vendored libretro emulator cores.
+
+## Repository map
+
+- `stable_retro/` is the primary Python package. `retro/` is a compatibility shim; keep both import paths working.
+- `src/` contains the native runtime, pybind11 bindings, and optional Qt integration UI.
+- `cores/<platform>/` contains vendored emulator source. Avoid broad cleanup or formatting there.
+- `cores/*.json` contains the source platform manifests consumed by `src/coreinfo.cpp`.
+- `stable_retro/cores/` contains generated build outputs. Do not edit its JSON, version stamps, or shared libraries directly.
+- `tests/test_python/` contains Python tests. `tests/*.cpp` contains native tests and small test ROM fixtures are under `tests/roms/`.
+- `docs/` is the Sphinx documentation source.
+
+## Environment and build
+
+- Supported Python versions are 3.10 through 3.14. Do not require a newer Python runtime.
+- On Debian/Ubuntu, install `cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev libbz2-dev xvfb python3-opengl libgl1-mesa-dev libglu1-mesa-dev`.
+- Install the package and development tools with `python -m pip install -e '.[dev]'`.
+- The tested native workflow uses an in-source CMake build because native tests resolve cores and ROM fixtures relative to the source tree.
+- Pass optional native settings through `STABLE_RETRO_CMAKE_ARGS` or `CMAKE_ARGS`, for example `CMAKE_ARGS='-DBUILD_N64=OFF' python -m pip install -e .`.
+
+## Validation
+
+- Python-only changes: run `scripts/test-python.sh`, optionally followed by a specific test path.
+- C++, CMake, core, or binding changes: run `CMAKE_BUILD_PARALLEL_LEVEL=2 scripts/test-cpp.sh`.
+- Formatting and repository checks: run `python -m pre_commit run --files <changed-files>`. Use `--all-files` before a broad pull request.
+- Documentation changes: install `docs/requirements.txt`, then run `sphinx-build -b dirhtml -v docs _build`.
+- Start with the narrowest relevant test, then run the full command required by the changed boundary.
+
+## Change rules
+
+- Keep changes focused and preserve existing public APIs unless the task explicitly changes one.
+- Do not commit generated CMake files, compiled objects, core shared libraries, or version-stamp files.
+- Do not add copyrighted commercial ROMs. Only use redistributable fixtures with clear provenance.
+- A new emulator platform normally requires a vendored libretro core, `cores/<platform>.json`, an `add_core` entry in `CMakeLists.txt`, packaging updates in `setup.py`, emulator smoke coverage, and documentation updates.
+- Core-specific runtime options belong in `src/emulator.cpp`. Add only options needed for deterministic headless execution, serialization, input, or rendering.
+- Work with existing uncommitted changes. Never clean or revert unrelated files as part of a task.

--- a/.github/instructions/cores.instructions.md
+++ b/.github/instructions/cores.instructions.md
@@ -1,0 +1,15 @@
+---
+description: "Use when adding or updating an emulator platform, libretro core, core manifest, ROM extension mapping, or platform support documentation."
+applyTo: "cores/**,CMakeLists.txt,setup.py,src/emulator.cpp,tests/emulator.cpp,docs/supported_emulators.md"
+---
+
+# Emulator Core Guidelines
+
+- Distinguish an emulator platform/core integration from a game integration under `stable_retro/data/`.
+- Edit the source manifest at `cores/<platform>.json`; files under `stable_retro/cores/` are generated.
+- Keep platform identifiers consistent across the manifest, integration directory suffixes in `setup.py`, tests, and documentation.
+- The manifest's `lib` must match the second argument of `add_core(<platform> <core_name>)`.
+- Verify every ROM extension is unambiguous because `src/coreinfo.cpp` maps extensions to platforms globally.
+- Avoid patching vendored core source when a top-level CMake flag or narrowly scoped adapter change can solve the problem.
+- Add a redistributable smoke-test fixture only when its license and provenance are clear.
+- Run `CMAKE_BUILD_PARALLEL_LEVEL=2 scripts/test-cpp.sh` and relevant Python tests before completion.

--- a/.github/instructions/native.instructions.md
+++ b/.github/instructions/native.instructions.md
@@ -1,0 +1,14 @@
+---
+description: "Use when changing C++, CMake, pybind11 bindings, native tests, rendering, or the Qt integration UI."
+applyTo: "CMakeLists.txt,src/**/*.cpp,src/**/*.h,tests/*.cpp,tests/CMakeLists.txt"
+---
+
+# Native Guidelines
+
+- Compile as C++14 and follow `.clang-format` without reformatting unrelated code.
+- Include each standard-library dependency directly instead of relying on transitive includes.
+- Keep platform-specific behavior behind the existing CMake options and preprocessor guards.
+- Treat `cores/` and `third-party/` as vendored code; change them only when the task specifically requires it.
+- Add focused GoogleTest coverage under `tests/` for native behavior changes.
+- Run `CMAKE_BUILD_PARALLEL_LEVEL=2 scripts/test-cpp.sh` after native or CMake changes.
+- If Python-visible bindings change, also run the relevant tests through `scripts/test-python.sh`.

--- a/.github/instructions/python.instructions.md
+++ b/.github/instructions/python.instructions.md
@@ -1,0 +1,13 @@
+---
+description: "Use when changing Stable Retro Python packages, Python tests, packaging metadata, or public Python APIs."
+applyTo: "stable_retro/**/*.py,retro/**/*.py,tests/test_python/**/*.py,setup.py,pyproject.toml"
+---
+
+# Python Guidelines
+
+- Treat `stable_retro` as the implementation package and `retro` as its compatibility shim.
+- Preserve Python 3.10 compatibility and follow the repository's Black, isort, Flake8, and pyupgrade configuration.
+- Keep Python wrappers consistent with native bindings exposed from `src/retro.cpp`.
+- Add or update focused tests under `tests/test_python/` for behavior changes.
+- Run `scripts/test-python.sh <test-path>` while iterating and `scripts/test-python.sh` before completion.
+- Run `python -m pre_commit run --files <changed-files>` for formatting and static checks.

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,9 +1,0 @@
-## Issue summary
-
-[Put a detailed description of the issue here.]
-
-## System information
-
-- [Operating system]
-- [Python version]
-- [Gym Retro version]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## Summary
+
+Describe the problem and the approach taken.
+
+## Change type
+
+- [ ] Bug fix
+- [ ] Feature or API change
+- [ ] Game integration
+- [ ] Emulator platform or core
+- [ ] Build, packaging, or CI
+- [ ] Documentation
+
+## Validation
+
+List the exact commands run and their results. Include manual checks and tested operating systems for behavior that cannot be automated.
+
+```text
+commands and results
+```
+
+## Checklist
+
+- [ ] I added or updated focused tests for behavior changes.
+- [ ] I ran pre-commit checks on changed first-party files.
+- [ ] I updated public documentation where needed.
+- [ ] I preserved compatibility or documented the intentional break.
+- [ ] I did not commit generated build outputs.
+- [ ] Any ROM, BIOS, firmware, key, state, or other binary fixture is redistributable and has documented provenance.

--- a/.github/skills/add-emulator-platform/SKILL.md
+++ b/.github/skills/add-emulator-platform/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: add-emulator-platform
 description: "Add or review a new emulator platform, game system, libretro core, ROM extension mapping, or core build target in Stable Retro. Use for platform ports and core integrations, not ordinary game integrations."
-argument-hint: "Describe the platform, libretro core, target operating systems, and available test ROM."
 ---
 
 # Add an Emulator Platform
@@ -44,8 +43,8 @@ Compare one nearby simple platform manifest and one platform with similar render
 Build the new core first:
 
 ```shell
-cmake -S . -B . -DCMAKE_DISABLE_FIND_PACKAGE_CapnProto=TRUE
-cmake --build . --parallel 2 --target <platform>
+cmake -DCMAKE_DISABLE_FIND_PACKAGE_CapnProto=TRUE .
+cmake --build . --target <platform> -- -j2
 ```
 
 Then run the native suite:

--- a/.github/skills/add-emulator-platform/SKILL.md
+++ b/.github/skills/add-emulator-platform/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: add-emulator-platform
+description: "Add or review a new emulator platform, game system, libretro core, ROM extension mapping, or core build target in Stable Retro. Use for platform ports and core integrations, not ordinary game integrations."
+argument-hint: "Describe the platform, libretro core, target operating systems, and available test ROM."
+---
+
+# Add an Emulator Platform
+
+Use this workflow for a new emulated system or libretro core. A game integration only adds data under `stable_retro/data/` and should follow `docs/integration.md` instead.
+
+## Gather requirements
+
+Before editing, establish:
+
+- Stable Retro platform identifier and game-directory suffix.
+- Core directory slug and expected libretro library basename.
+- Upstream repository, pinned revision, license, and redistribution terms.
+- ROM extensions, libretro joypad layout, RAM regions, serialization behavior, and BIOS needs.
+- Supported host matrix: Linux, Windows, macOS x86_64, and macOS arm64.
+- A legally redistributable smoke-test ROM, or a documented manual-test substitute.
+
+Compare one nearby simple platform manifest and one platform with similar rendering, BIOS, or architecture constraints. Do not assume a core's standalone defaults are suitable for deterministic, headless reinforcement learning.
+
+## Implement the platform
+
+1. Vendor the pinned core under `cores/<platform>/`. Preserve upstream licensing and avoid unrelated source edits.
+2. Ensure the core's Makefile produces `<core_name>_libretro` with the host shared-library suffix. The top-level `add_core` function expects this exact name.
+3. Copy [the manifest template](./assets/platform-manifest.json) to `cores/<platform>.json` and adapt it. The top-level key is the public platform identifier; `lib` is `<core_name>` from CMake.
+4. Keep `buttons` and `keybinds` aligned to libretro joypad IDs. Use `null` for unsupported positions and list only valid button names in `actions`.
+5. Validate the manifest before compiling:
+
+   ```shell
+   python .github/skills/add-emulator-platform/scripts/validate_manifest.py cores/<platform>.json
+   ```
+
+6. Add `add_core(<platform> <core_name>)` in `CMakeLists.txt`. Guard it when host support or system libraries are conditional.
+7. Add only required deterministic core options to `s_envVariables` in `src/emulator.cpp`. Prefer software rendering unless the core truly requires `ENABLE_HW_RENDER`.
+8. Add the platform suffix to `setup.py` only when packaged game integrations use that suffix. Core JSON and shared-library packaging is already generic.
+9. Update `tests/emulator.cpp` with manifest loading and an emulator smoke parameter when a redistributable fixture exists. Otherwise add lower-level mapping coverage and record manual load, frame, audio, reset, and serialization evidence.
+10. Update `docs/supported_emulators.md` and, when users can import games for the system, the supported ROM types in `docs/integration.md`.
+
+## Validate incrementally
+
+Build the new core first:
+
+```shell
+cmake -S . -B . -DCMAKE_DISABLE_FIND_PACKAGE_CapnProto=TRUE
+cmake --build . --parallel 2 --target <platform>
+```
+
+Then run the native suite:
+
+```shell
+CMAKE_BUILD_PARALLEL_LEVEL=2 scripts/test-cpp.sh
+```
+
+Run relevant Python tests and repository checks:
+
+```shell
+scripts/test-python.sh
+python -m pre_commit run --files <changed-files>
+```
+
+Use [the completion checklist](./references/checklist.md) before finishing. Clearly report any host platform or hardware path that was not tested.

--- a/.github/skills/add-emulator-platform/assets/platform-manifest.json
+++ b/.github/skills/add-emulator-platform/assets/platform-manifest.json
@@ -1,0 +1,14 @@
+{
+    "PlatformName": {
+        "lib": "core_name",
+        "ext": ["rom"],
+        "keybinds": ["Z", "A", "TAB", "ENTER", "UP", "DOWN", "LEFT", "RIGHT", "X", "S", "Q", "W", null, null, null, null],
+        "buttons": ["B", "Y", "SELECT", "START", "UP", "DOWN", "LEFT", "RIGHT", "A", "X", "L", "R", "L2", "R2", "L3", "R3"],
+        "actions": [
+            [[], ["UP"], ["DOWN"]],
+            [[], ["LEFT"], ["RIGHT"]],
+            [[], ["A"], ["B"], ["X"], ["Y"]],
+            [[], ["L"], ["R"], ["L", "R"]]
+        ]
+    }
+}

--- a/.github/skills/add-emulator-platform/references/checklist.md
+++ b/.github/skills/add-emulator-platform/references/checklist.md
@@ -1,0 +1,33 @@
+# Emulator Platform Completion Checklist
+
+## Core and licensing
+
+- The vendored source is pinned to a known upstream revision.
+- Upstream license files and required notices are present.
+- No commercial ROM, BIOS, key, firmware, or copyrighted test asset was added without redistribution permission.
+- Patches to vendored source are minimal and documented.
+
+## Manifest and runtime
+
+- `cores/<platform>.json` passes `validate_manifest.py`.
+- Platform identifier, core library basename, and integration directory suffix are consistent.
+- ROM extensions do not override an existing platform mapping.
+- Input labels and action combinations work for every exposed player/control.
+- RAM mapping, overlays, data types, and endianness were verified where applicable.
+- Load, frame output, audio, reset, unload, and serialization were exercised.
+- BIOS requirements and missing-BIOS errors are documented.
+
+## Build and packaging
+
+- The focused CMake core target builds on each claimed host platform.
+- Conditional host, architecture, rendering, and dependency checks fail or skip clearly.
+- Wheel or editable-install output contains the manifest and core shared library.
+- Generated files under `stable_retro/cores/` are not committed.
+
+## Tests and docs
+
+- Automated smoke coverage uses only redistributable fixtures with documented provenance.
+- `scripts/test-cpp.sh` and relevant Python tests pass.
+- Pre-commit checks pass for every changed first-party file.
+- Supported emulator, ROM extension, BIOS, and installation documentation is current.
+- Untested hosts and manual verification are stated in the pull request.

--- a/.github/skills/add-emulator-platform/scripts/validate_manifest.py
+++ b/.github/skills/add-emulator-platform/scripts/validate_manifest.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+from pathlib import Path
+
+
+class ManifestError(ValueError):
+    pass
+
+
+def require(condition, message):
+    if not condition:
+        raise ManifestError(message)
+
+
+def load_manifest(path):
+    try:
+        with path.open(encoding="utf-8") as manifest_file:
+            document = json.load(manifest_file)
+    except (OSError, json.JSONDecodeError) as error:
+        raise ManifestError(f"cannot read {path}: {error}") from error
+
+    require(
+        isinstance(document, dict) and document,
+        "manifest must be a non-empty object",
+    )
+    return document
+
+
+def validate_string_list(value, location, allow_null=False):
+    require(isinstance(value, list), f"{location} must be an array")
+    for index, item in enumerate(value):
+        valid = isinstance(item, str) and bool(item)
+        require(
+            valid or (allow_null and item is None),
+            f"{location}[{index}] must be a non-empty string"
+            + (" or null" if allow_null else ""),
+        )
+
+
+def validate_platform(platform, config):
+    location = f"platform {platform!r}"
+    require(
+        isinstance(platform, str) and platform,
+        "platform names must be non-empty strings",
+    )
+    require(isinstance(config, dict), f"{location} must contain an object")
+
+    library = config.get("lib")
+    require(
+        isinstance(library, str) and library,
+        f"{location}.lib must be a non-empty string",
+    )
+
+    extensions = config.get("ext")
+    validate_string_list(extensions, f"{location}.ext")
+    require(
+        len(extensions) == len(set(extensions)),
+        f"{location}.ext contains duplicates",
+    )
+    for extension in extensions:
+        require(
+            extension == extension.lower(),
+            f"extension {extension!r} must be lowercase",
+        )
+        require(
+            not extension.startswith("."),
+            f"extension {extension!r} must not start with a dot",
+        )
+        require(
+            not any(character.isspace() for character in extension),
+            f"extension {extension!r} must not contain whitespace",
+        )
+
+    buttons = config.get("buttons")
+    keybinds = config.get("keybinds")
+    validate_string_list(buttons, f"{location}.buttons", allow_null=True)
+    validate_string_list(keybinds, f"{location}.keybinds", allow_null=True)
+    require(
+        len(buttons) == len(keybinds),
+        f"{location}.buttons and keybinds must have equal lengths",
+    )
+
+    button_names = {button for button in buttons if button is not None}
+    require(
+        len(button_names) == sum(button is not None for button in buttons),
+        f"{location}.buttons contains duplicate names",
+    )
+
+    actions = config.get("actions", [])
+    require(isinstance(actions, list), f"{location}.actions must be an array")
+    for group_index, group in enumerate(actions):
+        require(
+            isinstance(group, list),
+            f"{location}.actions[{group_index}] must be an array",
+        )
+        for action_index, action in enumerate(group):
+            require(
+                isinstance(action, list),
+                f"{location}.actions[{group_index}][{action_index}] must be an array",
+            )
+            for button in action:
+                require(
+                    button in button_names,
+                    f"{location}.actions references unknown button {button!r}",
+                )
+
+    if "rambase" in config:
+        require(
+            isinstance(config["rambase"], int) and config["rambase"] >= 0,
+            f"{location}.rambase must be a non-negative integer",
+        )
+    if "types" in config:
+        validate_string_list(config["types"], f"{location}.types")
+    if "overlay" in config:
+        overlay = config["overlay"]
+        require(
+            isinstance(overlay, list) and len(overlay) == 3,
+            f"{location}.overlay must have three entries",
+        )
+        require(
+            all(isinstance(item, str) and len(item) == 1 for item in overlay[:2]),
+            f"{location}.overlay byte-order entries must be single characters",
+        )
+        require(
+            isinstance(overlay[2], int) and overlay[2] >= 0,
+            f"{location}.overlay offset must be a non-negative integer",
+        )
+
+
+def find_extension_owners(manifest_path):
+    owners = {}
+    for sibling in sorted(manifest_path.parent.glob("*.json")):
+        if sibling.resolve() == manifest_path.resolve():
+            continue
+        document = load_manifest(sibling)
+        for platform, config in document.items():
+            for extension in config.get("ext", []):
+                owners.setdefault(extension, []).append(f"{platform} ({sibling.name})")
+    return owners
+
+
+def validate_manifest(manifest_path):
+    document = load_manifest(manifest_path)
+    extension_owners = find_extension_owners(manifest_path)
+    extension_count = 0
+
+    for platform, config in document.items():
+        validate_platform(platform, config)
+        for extension in config["ext"]:
+            owners = extension_owners.get(extension, [])
+            require(
+                not owners,
+                f"extension {extension!r} is already mapped by {', '.join(owners)}",
+            )
+            extension_count += 1
+
+    print(
+        f"Validated {manifest_path}: {len(document)} platform entries, {extension_count} ROM extensions",
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Validate a Stable Retro core manifest",
+    )
+    parser.add_argument("manifest", type=Path, help="path to cores/<platform>.json")
+    args = parser.parse_args()
+
+    try:
+        validate_manifest(args.manifest)
+    except ManifestError as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/add-emulator-platform/scripts/validate_manifest.py
+++ b/.github/skills/add-emulator-platform/scripts/validate_manifest.py
@@ -14,11 +14,19 @@ def require(condition, message):
         raise ManifestError(message)
 
 
+def unique_object(pairs):
+    document = {}
+    for key, value in pairs:
+        require(key not in document, f"duplicate object key {key!r}")
+        document[key] = value
+    return document
+
+
 def load_manifest(path):
     try:
         with path.open(encoding="utf-8") as manifest_file:
-            document = json.load(manifest_file)
-    except (OSError, json.JSONDecodeError) as error:
+            document = json.load(manifest_file, object_pairs_hook=unique_object)
+    except (OSError, json.JSONDecodeError, ManifestError) as error:
         raise ManifestError(f"cannot read {path}: {error}") from error
 
     require(
@@ -129,35 +137,46 @@ def validate_platform(platform, config):
         )
 
 
-def find_extension_owners(manifest_path):
-    owners = {}
-    for sibling in sorted(manifest_path.parent.glob("*.json")):
-        if sibling.resolve() == manifest_path.resolve():
-            continue
-        document = load_manifest(sibling)
-        for platform, config in document.items():
-            for extension in config.get("ext", []):
-                owners.setdefault(extension, []).append(f"{platform} ({sibling.name})")
-    return owners
+def repository_manifest_paths(manifest_path):
+    paths = sorted(manifest_path.parent.glob("*.json"))
+    if not any(path.resolve() == manifest_path.resolve() for path in paths):
+        paths.append(manifest_path)
+    return paths
 
 
 def validate_manifest(manifest_path):
-    document = load_manifest(manifest_path)
-    extension_owners = find_extension_owners(manifest_path)
-    extension_count = 0
+    target_path = manifest_path.resolve()
+    platform_owners = {}
+    extension_owners = {}
+    target_platform_count = 0
+    target_extension_count = 0
 
-    for platform, config in document.items():
-        validate_platform(platform, config)
-        for extension in config["ext"]:
-            owners = extension_owners.get(extension, [])
+    for path in repository_manifest_paths(manifest_path):
+        document = load_manifest(path)
+        for platform, config in document.items():
+            validate_platform(platform, config)
+            owner = f"{platform} ({path.name})"
+            previous_platform_owner = platform_owners.get(platform)
             require(
-                not owners,
-                f"extension {extension!r} is already mapped by {', '.join(owners)}",
+                previous_platform_owner is None,
+                f"platform {platform!r} is already defined by {previous_platform_owner}",
             )
-            extension_count += 1
+            platform_owners[platform] = owner
+
+            for extension in config["ext"]:
+                previous_extension_owner = extension_owners.get(extension)
+                require(
+                    previous_extension_owner is None,
+                    f"extension {extension!r} is already mapped by {previous_extension_owner}",
+                )
+                extension_owners[extension] = owner
+
+            if path.resolve() == target_path:
+                target_platform_count += 1
+                target_extension_count += len(config["ext"])
 
     print(
-        f"Validated {manifest_path}: {len(document)} platform entries, {extension_count} ROM extensions",
+        f"Validated {manifest_path}: {target_platform_count} platform entries, {target_extension_count} ROM extensions",
     )
 
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,35 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 59
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev libbz2-dev xvfb python3-opengl libgl1-mesa-dev libglu1-mesa-dev
+
+      - name: Install Stable Retro and development tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e '.[dev]'

--- a/.github/workflows/test-cpp.yml
+++ b/.github/workflows/test-cpp.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install git cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev software-properties-common libbz2-dev python3-opengl
+          sudo apt-get install -y git cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev software-properties-common libbz2-dev python3-opengl
 
       - name: Build and run tests
         run: scripts/test-cpp.sh

--- a/.github/workflows/test-cpp.yml
+++ b/.github/workflows/test-cpp.yml
@@ -21,11 +21,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install git cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev software-properties-common libbz2-dev python3-opengl
 
-      - name: Install pip package and build tests
-        run: |
-          cmake -DCMAKE_DISABLE_FIND_PACKAGE_CapnProto=TRUE .
-          make -j2
-          make -j2 -f tests/Makefile
-
-      - name: Run tests
-        run: ctest --progress --verbose
+      - name: Build and run tests
+        run: scripts/test-cpp.sh
+        env:
+          CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -22,13 +22,12 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install git cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev software-properties-common libbz2-dev xvfb python3-opengl
+          sudo apt-get install git cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev software-properties-common libbz2-dev xvfb python3-opengl libglu1-mesa-dev
 
       - name: Install pip packages
         run: |
-          python3 -m pip install --upgrade pip pytest
-          python3 -m pip install -e .
+          python3 -m pip install --upgrade pip
+          python3 -m pip install -e '.[dev]'
 
       - name: Run tests
-        run: |
-          xvfb-run -s '-screen 0 1024x768x24' pytest
+        run: scripts/test-python.sh

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install system packages
         run: |
           sudo apt-get update
-          sudo apt-get install git cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev software-properties-common libbz2-dev xvfb python3-opengl libglu1-mesa-dev
+          sudo apt-get install -y git cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev software-properties-common libbz2-dev xvfb python3-opengl libglu1-mesa-dev
 
       - name: Install pip packages
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
           - --show-source
           - --statistics
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: [ "--py37-plus" ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v3.21.2
     hooks:
       - id: pyupgrade
-        args: [ "--py37-plus" ]
+        args: [ "--py310-plus" ]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,58 @@
 # Stable Retro Contribution Guidelines
 
-At this time we are currently accepting the current forms of contributions:
-
-- Bug reports in either the core functionality or game integrations
-- Pull requests for core functionality bug fixes
-
-Notably, we are not accepting these forms of contributions:
-
-- New game integrations
-- New features
-
-This may change in the future.
-In the meantime if you wish to integrate new games you are more than welcome to maintain unofficial repositories of additional games.
+Stable Retro welcomes bug reports, bug fixes, documentation improvements, new features, game integrations, and emulator platform work. Open an issue before beginning a large feature or core integration so its design, licensing, and platform support can be discussed early.
 
 ## Issue reports
 
-Please include the following information in your issue reports:
+Use the relevant GitHub issue form and include:
 
-- Operating system
+- Operating system and architecture
 - Python version
 - Stable Retro version or git commit
-- A detailed description of the issue
+- Emulator platform and core, when relevant
+- Reproduction steps, expected behavior, and complete error output
 
-## Code contributions
+Do not upload commercial ROMs, BIOS files, encryption keys, or other copyrighted assets to issues or pull requests.
 
-Please try to adhere to the existing code style. There is a linter script included at `scripts/lint.sh`.
-Before creating a pull request, make sure that your new code does not cause any tests to fail. To run the tests, see the instructions below.
+## Development setup
 
-#### Testing on Linux
+On Debian or Ubuntu, install the native dependencies:
+
 ```bash
-sudo apt-get install -y python3-opengl
-python3 -m pip install pytest
-pytest
+sudo apt-get update
+sudo apt-get install -y cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev libbz2-dev xvfb python3-opengl libgl1-mesa-dev libglu1-mesa-dev
 ```
 
-### Python
+Install Stable Retro and its development tools:
 
-Stable Retro is written in a [PEP 8-compliant code style](https://www.python.org/dev/peps/pep-0008/) (minus the line length restriction). Please make sure to maintain this style in any contributions.
+```bash
+python -m pip install -e '.[dev]'
+```
 
-### C++
+## Testing and style
 
-There is a `.clang-format` file that documents as best as possible the code style for Stable Retro. Please make sure to follow it.
+Run Python tests with:
+
+```bash
+scripts/test-python.sh
+```
+
+Run native tests with:
+
+```bash
+CMAKE_BUILD_PARALLEL_LEVEL=2 scripts/test-cpp.sh
+```
+
+Run repository checks on changed files with:
+
+```bash
+python -m pre_commit run --files <changed-files>
+```
+
+Python is formatted and checked by the tools configured in `.pre-commit-config.yaml`. C++ follows `.clang-format`. The legacy `scripts/lint.sh` command rewrites files in place; inspect your diff after using it.
+
+## Integration work
+
+- For a new game integration, follow `docs/integration.md`.
+- For a new emulator system or libretro core, account for licensing, host support, manifest mapping, packaging, native tests, and documentation. The repository workflow is captured in `.github/skills/add-emulator-platform/SKILL.md`.
+- Test fixtures must be freely redistributable and include clear provenance.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ More advanced examples:
 
 Documentation is available at [https://stable-retro.farama.org/](https://stable-retro.farama.org/) (work in progress)
 
-See [LICENSES.md](https://github.com/Farama-Foundation/stable-retro/blob/master/LICENSES.md) for information on the licenses of the individual cores.
+See [LICENSES.md](https://github.com/Farama-Foundation/stable-retro/blob/main/LICENSES.md) for information on the licenses of the individual cores.
 
 | Topic | Description |
 | --- | --- |
@@ -133,7 +133,7 @@ The following non-commercial Sega Genesis ROM is included with Stable Retro for 
 
 ## Contributing & Support
 
-[See CONTRIBUTING.md](https://github.com/Farama-Foundation/stable-retro/blob/master/CONTRIBUTING.md)
+[See CONTRIBUTING.md](https://github.com/Farama-Foundation/stable-retro/blob/main/CONTRIBUTING.md)
 
 For any issues, suggestions, or discussions related to Stable-Retro, please use [GitHub Issues](https://github.com/Farama-Foundation/stable-retro/issues) or the Farama Foundation's [Discord](https://discord.gg/aPjhD5cf).
 

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -2,7 +2,7 @@
 
 Adding new games can be done without recompiling Stable Retro, but if you need to work on the C++ code or make changes to the UI, you will want to compile Stable Retro from source.
 
-## Install Retro from source
+## Install Stable Retro from source
 
 Building Stable Retro requires at least either gcc 5 or clang 3.4.
 
@@ -12,14 +12,6 @@ To build Stable Retro you must first install CMake.
 You can do this either through your package manager, download from the [official site](https://cmake.org/download/) or `pip3 install cmake`.
 If you're using the official installer on Windows, make sure to tell CMake to add itself to the system PATH.
 
-### Mac prerequisites
-
-Since LuaJIT does not work properly on macOS you must first install Lua 5.1 from homebrew:
-
-```shell
-brew install pkg-config lua@5.1
-```
-
 ### Windows prerequisites
 
 Install docker
@@ -27,7 +19,8 @@ Install docker
 ### Linux prerequisites
 
 ```shell
-sudo apt-get install zlib1g-dev
+sudo apt-get update
+sudo apt-get install -y cmake capnproto zlib1g-dev build-essential pkg-config libzip-dev libbz2-dev xvfb python3-opengl libgl1-mesa-dev libglu1-mesa-dev
 ```
 
 ### Building Linux and Mac
@@ -35,8 +28,18 @@ sudo apt-get install zlib1g-dev
 ```shell
 git clone https://github.com/farama-foundation/stable-retro.git stable-retro
 cd stable-retro
-pip3 install -e .
+python -m pip install -e '.[dev]'
 ```
+
+Run Python and native tests through the same entry points used by CI:
+
+```shell
+scripts/test-python.sh
+CMAKE_BUILD_PARALLEL_LEVEL=2 scripts/test-cpp.sh
+python -m pre_commit run --all-files
+```
+
+The native test command uses an in-source CMake build because the test suite resolves core libraries and ROM fixtures relative to the source tree.
 
 ### Building Windows
 
@@ -53,7 +56,7 @@ Then you may pip install
 ```shell
 git clone https://github.com/farama-foundation/stable-retro.git stable-retro
 cd stable-retro
-pip3 install -e .
+python -m pip install -e '.[dev]'
 ```
 
 ## Install Retro UI from source
@@ -65,7 +68,7 @@ First make sure you can install Retro from source, after that follow the instruc
 Note that for Mojave (10.14) you may need to install `/Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg`
 
 ```shell
-brew install pkg-config capnp lua@5.1 qt5
+brew install pkg-config capnp qt5
 cmake . -DCMAKE_PREFIX_PATH=/usr/local/opt/qt -DBUILD_UI=ON -UPYLIB_DIRECTORY
 make -j$(sysctl hw.ncpu | cut -d: -f2)
 open "Gym Retro Integration.app"

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -105,7 +105,7 @@ import stable_retro
 stable_retro.data.list_games()
 ```
 
-The actual integration data can be see in the [Stable Retro Github repo](https://github.com/farama-foundation/stable-retro/tree/master/stable_retro/data/stable).
+The actual integration data can be seen in the [Stable Retro GitHub repository](https://github.com/farama-foundation/stable-retro/tree/main/stable_retro/data/stable).
 
 (importing-roms)=
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -169,6 +169,6 @@ python.md
 
 release_notes.md
 Github <https://github.com/Farama-Foundation/stable-retro>
-    Contribute to the Docs <https://github.com/Farama-Foundation/stable-retro/blob/main/docs/README.md>
+Contribute to the Docs <https://github.com/Farama-Foundation/stable-retro/blob/main/docs/README.md>
 ```
 [//]: # (release_notes/index)

--- a/docs/index.md
+++ b/docs/index.md
@@ -169,6 +169,6 @@ python.md
 
 release_notes.md
 Github <https://github.com/Farama-Foundation/stable-retro>
-Contribute to the Docs <https://github.com/Farama-Foundation/stable-retro/blob/master/docs/README.md>
+    Contribute to the Docs <https://github.com/Farama-Foundation/stable-retro/blob/main/docs/README.md>
 ```
 [//]: # (release_notes/index)

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -12,7 +12,7 @@ If you are going to integrate a new game, you'll need a ROM for the correct syst
 
 ## Example Integration
 
-This is a list of the integration files for the game [Airstriker-Genesis-v0](https://github.com/farama-foundation/stable-retro/blob/master/retro/data/stable/Airstriker-Genesis-v0).
+This is a list of the integration files for the game [Airstriker-Genesis-v0](https://github.com/farama-foundation/stable-retro/blob/main/stable_retro/data/stable/Airstriker-Genesis-v0).
 
 ### `Level1.state`
 
@@ -22,21 +22,21 @@ This is a savestate from the beginning of the game, restarting the environment w
 
 This file defines the list of game-related variables that python can see based on their memory addresses in the games
 
-```{literalinclude} ../retro/data/stable/Airstriker-Genesis-v0/data.json
+```{literalinclude} ../stable_retro/data/stable/Airstriker-Genesis-v0/data.json
 ```
 
 ### `scenario.json`
 
 This file defines the reward function and done condition using the variables defined in `data.json`
 
-```{literalinclude} ../retro/data/stable/Airstriker-Genesis-v0/scenario.json
+```{literalinclude} ../stable_retro/data/stable/Airstriker-Genesis-v0/scenario.json
 ```
 
 ### `metadata.json`
 
 This file defines the default starting state if no state is specified by the user as well as some miscellaneous debugging information.
 
-```{literalinclude} ../retro/data/stable/Airstriker-Genesis-v0/metadata.json
+```{literalinclude} ../stable_retro/data/stable/Airstriker-Genesis-v0/metadata.json
 ```
 
 ### `rom.md`
@@ -47,7 +47,7 @@ This is the ROM file used for this game, with a few exceptions, ROM files are no
 
 This is the SHA1 hash of the `rom.md` file, used for importing ROMs.
 
-```{literalinclude} ../retro/data/stable/Airstriker-Genesis-v0/rom.sha
+```{literalinclude} ../stable_retro/data/stable/Airstriker-Genesis-v0/rom.sha
 ```
 
 These are all the files used in an integration.  The next section will describe the files in more detail.
@@ -171,7 +171,7 @@ To integrate a game you need to define a done condition and a reward function.  
 
 To define these, you find variables from the game's memory, such as the player's current score and lives remaining, and use those to create the done condition and reward function.  An example done condition is when the `lives` variable is equal to `0`, an example reward function is the change in the `score` variable.
 
-Note: if the game requires that you hit the `Start` button to play, for instance after dying, then you need to modify the scenario file to allow this as `Start` is disallowed by default.  See the `actions` key in [KidChameleon-Genesis-v0](https://github.com/farama-foundation/stable-retro/blob/master/retro/data/stable/KidChameleon-Genesis-v0/scenario.json) for an example of this.
+Note: if the game requires that you hit the `Start` button to play, for instance after dying, then you need to modify the scenario file to allow this as `Start` is disallowed by default.  See the `actions` key in [KidChameleon-Genesis-v0](https://github.com/farama-foundation/stable-retro/blob/main/stable_retro/data/stable/KidChameleon-Genesis-v0/scenario.json) for an example of this.
 
 ### Done Condition
 

--- a/docs/python.md
+++ b/docs/python.md
@@ -28,7 +28,7 @@ There are a few possible action spaces included with {class}`stable_retro.RetroE
    :members:
 ```
 
-You can also create your own action spaces derived from these.  For an example, see [discretizer.py](https://github.com/farama-foundation/stable-retro/blob/master/stable_retro/examples/discretizer.py).  This file shows how to use `stable_retro.Actions.Discrete` as well as how to make a custom wrapper that reduces the action space from `126` actions to `7`
+You can also create your own action spaces derived from these.  For an example, see [discretizer.py](https://github.com/farama-foundation/stable-retro/blob/main/stable_retro/examples/discretizer.py).  This file shows how to use `stable_retro.Actions.Discrete` as well as how to make a custom wrapper that reduces the action space from `126` actions to `7`
 
 ## Observations
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
 ]
 dynamic = ["version"]
 
+[project.optional-dependencies]
+dev = ["autopep8", "pre-commit", "pytest"]
+
 [project.urls]
 Homepage = "https://github.com/Farama-Foundation/stable-retro"
 Repository = "https://github.com/Farama-Foundation/stable-retro"

--- a/scripts/benchmark_cores.py
+++ b/scripts/benchmark_cores.py
@@ -20,9 +20,9 @@ import gc
 import json
 import os
 import time
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 
 def _set_single_thread_env() -> None:

--- a/scripts/test-cpp.sh
+++ b/scripts/test-cpp.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if [[ -n "${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]]; then
+	jobs="${CMAKE_BUILD_PARALLEL_LEVEL}"
+elif command -v nproc >/dev/null 2>&1; then
+	jobs="$(nproc)"
+else
+	jobs="2"
+fi
+
+cmake -S . -B . -DCMAKE_DISABLE_FIND_PACKAGE_CapnProto=TRUE "$@"
+cmake --build . --parallel "${jobs}"
+cmake --build . --parallel "${jobs}" --target build-tests
+ctest --test-dir . --output-on-failure -R '^(data|emulator|memory-overlay|memory|script|search)$'

--- a/scripts/test-cpp.sh
+++ b/scripts/test-cpp.sh
@@ -12,7 +12,10 @@ else
 	jobs="2"
 fi
 
-cmake -S . -B . -DCMAKE_DISABLE_FIND_PACKAGE_CapnProto=TRUE "$@"
-cmake --build . --parallel "${jobs}"
-cmake --build . --parallel "${jobs}" --target build-tests
-ctest --test-dir . --output-on-failure -R '^(data|emulator|memory-overlay|memory|script|search)$'
+cmake -DCMAKE_DISABLE_FIND_PACKAGE_CapnProto=TRUE "$@" .
+cmake --build . -- -j"${jobs}"
+cmake --build . --target build-tests -- -j"${jobs}"
+(
+	cd tests
+	ctest --output-on-failure
+)

--- a/scripts/test-python.sh
+++ b/scripts/test-python.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+if command -v xvfb-run >/dev/null 2>&1; then
+	exec xvfb-run -a -s '-screen 0 1024x768x24' python -m pytest "$@"
+fi
+
+exec python -m pytest "$@"

--- a/tests/test_python/test_platform_manifest_validator.py
+++ b/tests/test_python/test_platform_manifest_validator.py
@@ -1,0 +1,87 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR = (
+    REPOSITORY_ROOT
+    / ".github"
+    / "skills"
+    / "add-emulator-platform"
+    / "scripts"
+    / "validate_manifest.py"
+)
+
+
+def platform(extension, library="core"):
+    return {
+        "lib": library,
+        "ext": [extension],
+        "keybinds": ["Z"],
+        "buttons": ["A"],
+        "actions": [[[], ["A"]]],
+    }
+
+
+def write_manifest(path, document):
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+def run_validator(manifest):
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR), str(manifest)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_accepts_unique_repository_mappings(tmp_path):
+    write_manifest(tmp_path / "existing.json", {"Existing": platform("old")})
+    target = tmp_path / "target.json"
+    write_manifest(target, {"Target": platform("new")})
+
+    result = run_validator(target)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_rejects_extension_collision_within_target(tmp_path):
+    target = tmp_path / "target.json"
+    write_manifest(
+        target,
+        {
+            "First": platform("rom", "first"),
+            "Second": platform("rom", "second"),
+        },
+    )
+
+    result = run_validator(target)
+
+    assert result.returncode != 0
+    assert "extension 'rom' is already mapped" in result.stderr
+
+
+def test_rejects_platform_collision_with_sibling(tmp_path):
+    write_manifest(tmp_path / "existing.json", {"Duplicate": platform("old")})
+    target = tmp_path / "target.json"
+    write_manifest(target, {"Duplicate": platform("new")})
+
+    result = run_validator(target)
+
+    assert result.returncode != 0
+    assert "platform 'Duplicate' is already defined" in result.stderr
+
+
+def test_rejects_duplicate_json_keys(tmp_path):
+    target = tmp_path / "target.json"
+    target.write_text(
+        '{"Duplicate":{"lib":"first"},"Duplicate":{"lib":"second"}}',
+        encoding="utf-8",
+    )
+
+    result = run_validator(target)
+
+    assert result.returncode != 0
+    assert "duplicate object key 'Duplicate'" in result.stderr


### PR DESCRIPTION
## Summary

- add repository-wide and path-specific Copilot instructions plus deterministic cloud-agent setup
- add an emulator-platform integration skill with a manifest validator and completion checklist
- share Python and native test entry points across developers and CI
- modernize contribution guidance, issue forms, pull request template, and stale documentation links
- declare development dependencies and update pyupgrade for Python 3.14 compatibility

## Validation

- `python -m pre_commit run --files <all changed files>`: passed
- manifest validator: all 13 existing source manifests passed
- `CMAKE_BUILD_PARALLEL_LEVEL=2 scripts/test-cpp.sh`: 6/6 Stable Retro native suites passed
- `scripts/test-python.sh`: 3130 passed, 10 skipped, 30 rendering failures because local `libGLU` is absent; CI and Copilot setup now install `libglu1-mesa-dev`
- Sphinx build not completed because the pinned `sphinx-gallery` Git dependency fetch stalled, including through the configured proxy