### PR TITLE
Fix macOS integration file dialogs

### DIFF
--- a/src/ui/main.cpp
+++ b/src/ui/main.cpp
@@ -19,6 +19,9 @@ int main(int argc, char* argv[]) {
 #ifdef Q_OS_WIN
 	QCoreApplication::setAttribute(Qt::AA_NativeWindows);
 #endif
+#ifdef Q_OS_MACOS
+	QCoreApplication::setAttribute(Qt::AA_DontUseNativeDialogs);
+#endif
 
 	QApplication app(argc, argv);
 


### PR DESCRIPTION
## Summary

Fixes #264 by disabling Qt's native file dialogs on macOS. This makes the Integration UI use Qt's widget-based picker for all file and directory selection actions.

## Change type

- [x] Bug fix

## Validation

```text
python -m pre_commit run --files src/ui/main.cpp
Passed

Not run: Integration UI build/runtime test. This Linux checkout has BUILD_UI=OFF and no Qt development headers; macOS manual verification is still required.
```

## Checklist

- [ ] I added or updated focused tests for behavior changes.
- [x] I ran pre-commit checks on changed first-party files.
- [ ] I updated public documentation where needed.
- [x] I preserved compatibility or documented the intentional break.
- [x] I did not commit generated build outputs.
- [x] Any ROM, BIOS, firmware, key, state, or other binary fixture is redistributable and has documented provenance.
