### PR TITLE
ci: avoid pip 26.2 resolver failure on Python 3.11

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install pip packages
         run: |
-          python3 -m pip install --upgrade pip
+          python3 -m pip install --upgrade "pip<26.2"
           python3 -m pip install -e '.[dev]'
 
       - name: Run tests


### PR DESCRIPTION
## Summary

- keep Python test CI on `pip<26.2`
- avoid the pip 26.2 resolver failure for the Python 3.11 job

## Validation

- `python -m pre_commit run --files .github/workflows/test-python.yml`
- pip 26.1.2 dry-run resolver for Python 3.11 selects `pre-commit 4.6.2`