### PR TITLE
Re-enable Linux ARM binary wheel builds

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -36,7 +36,10 @@ jobs:
         uses: pypa/cibuildwheel@v4.2.0
         env:
           # Configure cibuildwheel to build native archs, and some emulated ones
-          CIBW_ARCHS_LINUX: x86_64 # aarch64 - disable ARM, as it's not working for a moment
+          CIBW_ARCHS_LINUX: x86_64 aarch64
+          # FBNeo ships x86 object files and Parallel N64 uses an x86 dynarec.
+          CIBW_ENVIRONMENT_LINUX: >
+            CMAKE_ARGS="$(test \"$(uname -m)\" = aarch64 && echo '-DBUILD_FBNEO=OFF -DBUILD_N64=OFF')"
           #CIBW_ARCHS_MACOS: x86_64 arm64 - macos is disabled for a moment
           CIBW_BUILD_VERBOSITY: 3  # Increase verbosity to see what's going on
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: >  # Print additional info from auditwheel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ option(BUILD_MANYLINUX "Should use static libraries compatible with manylinux1"
 option(ENABLE_HW_RENDER
        "Enable hardware rendering support for GPU cores (requires EGL/OpenGL)"
        OFF)
+option(BUILD_FBNEO "Build FinalBurn Neo arcade core" ON)
 option(BUILD_N64 "Build Parallel N64 core (requires OpenGL headers)" ON)
 
 set(BUILD_PYTHON
@@ -268,7 +269,11 @@ if(APPLE)
       "FBNeo arcade and parallel N64 emulator is currently not supported on macOS"
   )
 else()
-  add_core(fbneo fbneo)
+  if(BUILD_FBNEO)
+    add_core(fbneo fbneo)
+  else()
+    message(STATUS "BUILD_FBNEO=OFF: skipping FBNeo core")
+  endif()
   if(BUILD_N64)
     if(STABLE_RETRO_HAVE_GL_GL_H)
       add_core(n64 parallel_n64)


### PR DESCRIPTION
Closes #268

Re-enables aarch64 in CIBW_ARCHS_LINUX, using the existing QEMU setup to build Linux ARM wheels.